### PR TITLE
Pgbouncer

### DIFF
--- a/examples/deployments/persistant_db/helmfile.yaml
+++ b/examples/deployments/persistant_db/helmfile.yaml
@@ -5,7 +5,7 @@ releases:
     # Use of a specific relaease. 
     # chart: https://github.com/LamaAni/PGXL-HELM/archive/0.5.0.tar.gz
     # Chart in directory
-    chart: ../../
+    chart: ../../../
     values:
       - ./values.yaml
     # can also added inline, example:

--- a/examples/deployments/with_password/helmfile.yaml
+++ b/examples/deployments/with_password/helmfile.yaml
@@ -5,7 +5,7 @@ releases:
     # Use of a specific relaease. 
     # chart: https://github.com/LamaAni/PGXL-HELM/archive/0.5.0.tar.gz
     # Chart in directory
-    chart: ../../
+    chart: ../../../
     values:
       - ./values.yaml
       # can also added inline, example:

--- a/experimental/pgbouncer/install.sh
+++ b/experimental/pgbouncer/install.sh
@@ -6,7 +6,7 @@ PASSWORD="your_password"
 #=================================================================================================
 # SETUP PGXL
 #-------------------------------------------------------------------------------------------------
-git clone https://github.com/LamaAni/PGXL-HELM.git
+git clone --single-branch --branch pgbouncer https://github.com/sstubbs/PGXL-HELM.git
 cd PGXL-HELM/examples/deployments/with_password
 
 BASE64_PASSWORD=$(printf "${PASSWORD}" | base64)

--- a/experimental/pgbouncer/install.sh
+++ b/experimental/pgbouncer/install.sh
@@ -31,5 +31,54 @@ rm -rf PGXL-HELM
 #=================================================================================================
 # SETUP PGBOUNCER
 #-------------------------------------------------------------------------------------------------
+echo "apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgbouncer-deployment
+  labels:
+    app: pgbouncer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pgbouncer
+  template:
+    metadata:
+      labels:
+        app: pgbouncer
+    spec:
+      containers:
+      - name: pgbouncer
+        image: pgbouncer/pgbouncer:1.11.0
+        ports:
+        - containerPort: 5432
+        command:
+          - "sh"
+          - "-c"
+          - >
+            echo \"
+              [databases]
+              * = host = zav-db-tran-postgres-xl-svc port=5432
 
+              [pgbouncer]
+              max_client_conn = 1000
+              default_pool_size = 5
+              max_db_connections = 100
+              listen_addr = *
+              listen_port = 5432
+              auth_type = md5
+              ignore_startup_parameters = extra_float_digits, intervalStyle
+              auth_file = /etc/pgbouncer/userlist.txt
+              auth_query = SELECT p_user, p_password FROM connection_pool.lookup(\\\$1)
+              auth_user = postgres
+
+              # Log settings
+              admin_users = postgres\" > /etc/pgbouncer/pgbouncer.ini;
+            MD5_CREDENTIALS="md5$(echo -n "${PASSWORD}postgres" | md5sum | awk '{print $1}')"; echo \"\\\"postgres\\\" \\\"\${MD5_CREDENTIALS}\\\"\" > /etc/pgbouncer/userlist.txt;
+            exec /opt/pgbouncer/pgbouncer /etc/pgbouncer/pgbouncer.ini;" > pgbouncer-deployment.yaml
+
+
+kubectl apply -f pgbouncer-deployment.yaml
+
+rm -rf pgbouncer-deployment.yaml
 #=================================================================================================

--- a/experimental/pgbouncer/install.sh
+++ b/experimental/pgbouncer/install.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+SECRETS_FILE="pwd_secret.yaml"
+PASSWORD="your_password"
+
+#=================================================================================================
+# SETUP PGXL
+#-------------------------------------------------------------------------------------------------
+git clone https://github.com/LamaAni/PGXL-HELM.git
+cd PGXL-HELM/examples/deployments/with_password
+
+BASE64_PASSWORD=$(printf "${PASSWORD}" | base64)
+
+echo "apiVersion: v1
+kind: Secret
+metadata:
+  name:  pgxl-passwords-collection
+type: Opaque
+data:
+  # You must base64 encode your values. See: https://kubernetes.io/docs/concepts/configuration/secret/
+  pgpass: \"${BASE64_PASSWORD}\"" > "${SECRETS_FILE}"
+
+kubectl apply -f $SECRETS_FILE || exit 1
+helmfile sync || exit 1
+
+cd ../../../../
+rm -rf PGXL-HELM
+
+#=================================================================================================
+
+#=================================================================================================
+# SETUP PGBOUNCER
+#-------------------------------------------------------------------------------------------------
+
+#=================================================================================================


### PR DESCRIPTION
Hi,

I've had some time to look at this.

The helmfile chart path didnt work for me so I've fixed it here and also added a deployment script for pgbouncer without vault. It is working for me.

I can't find where you running the sql to alter the postgres password to the secret but perhaps we could add the pg_shadow function there. Otherwise just provide it in the readme that users must add the function. Here is how I did it in the staging cluster of swarm that I was using before k8s that has been working for a few months.

```
# SETUP DYNAMIC CONNECTION POOL FUNCTION
LOOKUP_FUNCTION="
CREATE SCHEMA IF NOT EXISTS connection_pool;
GRANT USAGE ON SCHEMA connection_pool TO ${CONNECTION_POOL_USERNAME};
CREATE OR REPLACE FUNCTION connection_pool.lookup (
   INOUT p_user     name,
   OUT   p_password text
) RETURNS record
   LANGUAGE sql SECURITY DEFINER SET search_path = pg_catalog AS
\$FUNC\$ SELECT usename, passwd FROM pg_shadow WHERE usename = p_user \$FUNC\$;
REVOKE EXECUTE ON FUNCTION connection_pool.lookup(name) FROM PUBLIC;
GRANT EXECUTE ON FUNCTION connection_pool.lookup(name) TO ${CONNECTION_POOL_USERNAME};
"
psql -d template1 -c "${LOOKUP_FUNCTION}" || true
psql -d postgres -c "${LOOKUP_FUNCTION}" || true
sleep 5
psql -c "CLEAN CONNECTION TO ALL FOR template1;"
```
Will get the install script for pgbouncer with vault in a pr later today.

 