### PR TITLE
Small fix for PID lock on gtm restore.

### DIFF
--- a/scripts/gtm_entrypoint
+++ b/scripts/gtm_entrypoint
@@ -35,6 +35,11 @@ if [ -z "$control_info" ]; then
 
 else
   echo "$LOGGING_PREFIX GTM configuration found, init skipped."
+  if [ -f "${PGDATA}/gtm.pid" ]; then
+    echo "$LOGGING_PREFIX GTM process not shut down properly, lock file gtm.pid still exists. Deleting."
+    rm "${PGDATA}/gtm.pid"
+  fi
+  
   echo "$LOGGING_PREFIX Current control state:"
   echo "$control_info"
   echo

--- a/scripts/register_node
+++ b/scripts/register_node
@@ -3,15 +3,18 @@
 cur_path="$(dirname ${BASH_SOURCE[0]})"
 source "$cur_path/initialize_env_dependencies"
 
-while true; do
-  pg_isready &> /dev/null 
-  if [ $? -eq 0 ]; then
-    break
-  else 
-    echo "$LOGGING_PREFIX Waiting for database to be ready before starting cluster register"
-    sleep $PORT_WAIT_INTERVAL
-  fi
-done
+function wait_for_postgres(){
+  while true; do
+    pg_isready &> /dev/null 
+    if [ $? -eq 0 ]; then
+      break
+    else 
+      echo "$LOGGING_PREFIX Waiting for database to be ready.."
+      sleep $PORT_WAIT_INTERVAL
+    fi
+  done
+}
+
 
 echo "$LOGGING_PREFIX Registering cluster nodes on $POD_NAME.."
 
@@ -29,7 +32,13 @@ function register_node(){
       node_host="${node_full_name}.${COORDINATOR_SERVICE}"
       node_name="CN_$i"
     ;;
+    *)
+      echo "$LOGGING_PREFIX ERROR: Register node is defined only for datanodes and coordinators"
+      exit 1
+    ;;
   esac
+
+  wait_for_postgres || return $?
 
   local cmd="CREATE"
   local host_ip="$POD_IP"


### PR DESCRIPTION
Since the gtm has a restore process that copies the current data state (and node register state) of the gtm, we might be copying the pid lock file. 

This needs to get removed on gtm start.

Also, for the coordinator, since gtm is being restored and takes a while, postgres might get disconnected. Therefore added wait for postgres method in the register. 