### PR TITLE
Added fix for long names using host aliases.

### DIFF
--- a/scripts/register_node
+++ b/scripts/register_node
@@ -24,12 +24,12 @@ function register_node(){
   case "$type" in 
     datanode)
       node_full_name="${DATANODE_BASENAME}-${idx}"
-      node_host="${node_full_name}.${DATANODE_SERVICE}"
+      node_host="local-alias-dn-$i"
       node_name="DN_$i"
     ;;
     coordinator)
       node_full_name="${COORDINATOR_BASENAME}-${idx}"
-      node_host="${node_full_name}.${COORDINATOR_SERVICE}"
+      node_host="local-alias-crd-$i"
       node_name="CN_$i"
     ;;
     *)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -7,7 +7,7 @@ Create a default fully qualified kubernetes name, with max 50 chars,
 thus alowing for 13 chars of internal naming.
 */}}
 {{- define "to_kube_valid_name" -}}
-  {{- include "clean_kube_name" (dict "name" .name) | trunc 50 | trimSuffix "-" -}}
+  {{- include "clean_kube_name" (dict "name" .name) | trunc 45 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "gloabl.chart_name" -}}

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -22,3 +22,22 @@ data:
   gtm_config_append: |
     # applies only on startup.
     log_min_messages = {{ upper .Values.config.log_level }}
+
+  host_aliases: | 
+    # list of hosts to alias, for datanode and coordinators.
+    # These short names are required by pg since the host 
+    # name is truncated by the Create Node sql query.
+    local-alias-gtm {{ $app_name }}-gtm-0.{{ $app_name }}-svc-gtm
+
+{{- range $i := until (int .Values.datanodes.count) }}
+    local-alias-dn-{{ $i }} {{ $app_name }}-dn-{{ $i }}.{{ $app_name }}-svc-dn
+{{- end }}
+
+{{- range $i := until (int .Values.coordinators.count) }}
+    local-alias-crd-{{ $i }} {{ $app_name }}-crd-{{ $i }}.{{ $app_name }}-svc-crd
+{{- end }}
+
+{{- range $i := until (int .Values.proxies.count) }}
+    local-alias-pxy-{{ $i }} {{ $app_name }}-pxy-{{ $i }}.{{ $app_name }}-svc-pxy
+{{- end }}
+

--- a/templates/envs.yaml
+++ b/templates/envs.yaml
@@ -33,6 +33,7 @@ data:
   PG_HOST: "0.0.0.0"
   PGDATA: "{{ .Values.homedir }}/storage/data"
   STORAGE_MOUNT_PATH: "{{ .Values.homedir }}/storage"
+  HOSTALIASES: "/config/host_aliases"
 
   GTM_BASENAME: "{{ $app_name }}-gtm"
   GTM_SERVICE: "{{ $app_name }}-svc-gtm"


### PR DESCRIPTION
## What:
Changed the inner container host resolve for postgres and nc using HOSTALIASES enviroment variable. The host names are now aliased by,
```
local-alias-[type]-[#]
```
For example, for a datanode: 
```
local-alias-dn-0
```

The aliases are loaded into the config directory @ `/config/host_aliases` and a env is added named `HOSTALIASES=/config/host_aliases` to match.

Then, create node uses these aliases to connect to the other nodes on the network.

## Why:
Fix for issue: https://github.com/LamaAni/postgres-xl-helm/issues/36