### PR TITLE
Fix config append

### DIFF
--- a/examples/deployments/with_configuration/helmfile.yaml
+++ b/examples/deployments/with_configuration/helmfile.yaml
@@ -1,0 +1,15 @@
+# generate a transiant postgres-xl db. This db will 
+# NOT be able to withstand restarts.
+releases:
+  - name: db-with-config
+    # Use of a specific relaease. 
+    # chart: https://github.com/LamaAni/postgres-xl-helm/archive/0.5.0.tar.gz
+    # Chart in directory
+    chart: ../../../
+    values:
+      - ./values.yaml
+      # can also added inline, example:
+      # - datanodes:
+      #     count: 4  
+      #   coordinators:
+      #     count: 2

--- a/examples/deployments/with_configuration/values.yaml
+++ b/examples/deployments/with_configuration/values.yaml
@@ -1,0 +1,30 @@
+# yaml anchor
+small_resource_limit: &small_resource_limit
+    limits:
+      memory: "500Mi"
+      cpu: "250m"
+
+gtm:
+  resources: *small_resource_limit
+datanodes:
+  count: 1
+  resources: *small_resource_limit
+coordinators:
+  count: 1
+  resources: *small_resource_limit
+proxies:
+  count: 1
+  enabled: true
+  resources: *small_resource_limit
+
+config:
+  append:
+    gtm: | 
+      # comment to gtm.
+    proxy: |
+      # comment to proxy.
+    datanode: |
+      # comment to datanode.
+    coordinator: | 
+      # comment to coordinator.
+      max_connections = 1000

--- a/scripts/gtm_entrypoint
+++ b/scripts/gtm_entrypoint
@@ -29,10 +29,8 @@ if [ -z "$control_info" ]; then
 
   initgtm -D "${PGDATA}" -Z gtm
 
-  cat /config/gtm_config_append >> "${PGDATA}/gtm.conf"
-  cat /config/config_append >> "${PGDATA}/gtm.conf"
-  source "$cur_path/initialize_networks"
-  source "$cur_path/initialize_node_config"
+  source "$cur_path/initialize_networks" || exit $?
+  source "$cur_path/initialize_node_config" || exit $?
 
 else
   echo "$LOGGING_PREFIX GTM configuration found, init skipped."

--- a/scripts/gtm_entrypoint
+++ b/scripts/gtm_entrypoint
@@ -32,6 +32,7 @@ if [ -z "$control_info" ]; then
   cat /config/gtm_config_append >> "${PGDATA}/gtm.conf"
   cat /config/config_append >> "${PGDATA}/gtm.conf"
   source "$cur_path/initialize_networks"
+  source "$cur_path/initialize_node_config"
 
 else
   echo "$LOGGING_PREFIX GTM configuration found, init skipped."

--- a/scripts/initialize_node_config
+++ b/scripts/initialize_node_config
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # Initialize the node configuration.
-cur_path="$(dirname ${BASH_SOURCE[0]})"
-echo "$LOGGING_PREFIX Initializing database on node $PG_NODE"
+# cur_path="$(dirname ${BASH_SOURCE[0]})"
+echo "$LOGGING_PREFIX Initializing node configuration for $NODE_TYPE @ $PG_NODE"
 
 node_config_file=""
 config_target_file=""
 
 case "$NODE_TYPE" in
 gtm)
-  config_target_file="${PGDATA}/gtm_proxy.conf"
+  config_target_file="${PGDATA}/gtm.conf"
   node_config_file="/config/config_append_gtm"
   ;;
 datanode)
@@ -29,5 +29,7 @@ proxy)
   ;;
 esac
 
-cat /config/config_append_internal_global >> $config_target_file
-cat "$node_config_file" >> $config_target_file
+cat "/config/config_append_internal_global" >> "$config_target_file" || exit 1
+cat "$node_config_file" >> "$config_target_file" || exit 1
+
+echo "$LOGGING_PREFIX Node configuration added to $config_target_file"

--- a/scripts/initialize_node_config
+++ b/scripts/initialize_node_config
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Initialize the node configuration.
+cur_path="$(dirname ${BASH_SOURCE[0]})"
+echo "$LOGGING_PREFIX Initializing database on node $PG_NODE"
+
+node_config_file=""
+config_target_file=""
+
+case "$NODE_TYPE" in
+gtm)
+  config_target_file="${PGDATA}/gtm_proxy.conf"
+  node_config_file="/config/config_append_gtm"
+  ;;
+datanode)
+  config_target_file="${PGDATA}/postgresql.conf"
+  node_config_file="/config/config_append_datanode"
+  ;;
+coordinator)
+  config_target_file="${PGDATA}/postgresql.conf"
+  node_config_file="/config/config_append_coordinator"
+  ;;
+proxy)
+  config_target_file="${PGDATA}/gtm_proxy.conf"
+  node_config_file="/config/config_append_proxy"
+  ;;
+*)
+  echo "$LOGGING_PREFIX Node configuration dose not exist for type $NODE_TYPE, error in condfig."
+  exit 1
+  ;;
+esac
+
+cat /config/config_append_internal_global >> $config_target_file
+cat "$node_config_file" >> $config_target_file

--- a/scripts/initialize_postgres_db
+++ b/scripts/initialize_postgres_db
@@ -34,9 +34,7 @@ if [ ! -f "${PGDATA}/postgresql.conf" ]; then
   export PG_PW_FILE
 
   source "$cur_path/initialize_networks"
-
-  cat /config/pg_config_append >> "${PGDATA}/postgresql.conf"
-  cat /config/config_append >> "${PGDATA}/postgresql.conf"
+  source "$cur_path/initialize_node_config"
 
   echo "$LOGGING_PREFIX Database configuration initialized."
 else

--- a/scripts/initialize_postgres_db
+++ b/scripts/initialize_postgres_db
@@ -33,8 +33,8 @@ if [ ! -f "${PGDATA}/postgresql.conf" ]; then
 
   export PG_PW_FILE
 
-  source "$cur_path/initialize_networks"
-  source "$cur_path/initialize_node_config"
+  source "$cur_path/initialize_networks" || exit $?
+  source "$cur_path/initialize_node_config" || exit $?
 
   echo "$LOGGING_PREFIX Database configuration initialized."
 else

--- a/scripts/proxy_entrypoint
+++ b/scripts/proxy_entrypoint
@@ -8,8 +8,8 @@ source "$cur_path/initialize_env_dependencies"
 initgtm -D "${PGDATA}" -Z gtm_proxy
 
 # config
-source "$cur_path/initialize_networks"
-source "$cur_path/initialize_node_config"
+source "$cur_path/initialize_networks" || exit $?
+source "$cur_path/initialize_node_config" || exit $?
 
 # start the proxy.
 PROXY_ID="$POD_CLUSTER_INDEX"

--- a/scripts/proxy_entrypoint
+++ b/scripts/proxy_entrypoint
@@ -8,9 +8,8 @@ source "$cur_path/initialize_env_dependencies"
 initgtm -D "${PGDATA}" -Z gtm_proxy
 
 # config
-cat /config/gtm_config_append >> "${PGDATA}/gtm_proxy.conf"
-cat /config/config_append >> "${PGDATA}/gtm_proxy.conf"
 source "$cur_path/initialize_networks"
+source "$cur_path/initialize_node_config"
 
 # start the proxy.
 PROXY_ID="$POD_CLUSTER_INDEX"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -8,20 +8,37 @@ metadata:
     app: {{ $app_name }}
     chart: {{ $chart_name }}
 data:
-  config_append: |
+  config_append_internal_global: |
     # applies only on startup.
     listen_addresses = '*'
-{{- if .Values.config.append }}
-{{ .Values.config.append | indent 4 }}
-{{- end }}
 
-  pg_config_append: |
-    # applies only on startup.
-    log_min_messages = {{ lower .Values.config.log_level }}
-
-  gtm_config_append: |
+  config_append_gtm: |
     # applies only on startup.
     log_min_messages = {{ upper .Values.config.log_level }}
+{{- if .Values.config.append.gtm }}
+{{ .Values.config.append.gtm | indent 4 }}
+{{- end }}
+
+  config_append_proxy: |
+    # applies only on startup.
+    log_min_messages = {{ upper .Values.config.log_level }}
+{{- if .Values.config.append.proxy }}
+{{ .Values.config.append.proxy | indent 4 }}
+{{- end }}
+
+  config_append_datanode: |
+    # applies only on startup.
+    log_min_messages = {{ lower .Values.config.log_level }}
+{{- if .Values.config.append.datanode }}
+{{ .Values.config.append.datanode | indent 4 }}
+{{- end }}
+
+  config_append_coordinator: |
+    # applies only on startup.
+    log_min_messages = {{ lower .Values.config.log_level }}
+{{- if .Values.config.append.coordinator }}
+{{ .Values.config.append.coordinator | indent 4 }}
+{{- end }}
 
   host_aliases: | 
     # list of hosts to alias, for datanode and coordinators.

--- a/values.yaml
+++ b/values.yaml
@@ -34,7 +34,7 @@ config:
     # append to all datanodes.
     datanode:
     # append to all coordinators.
-    coordinators:
+    coordinator:
 
 security:
   # If exists will load all passwords from secrets.

--- a/values.yaml
+++ b/values.yaml
@@ -25,8 +25,16 @@ config:
   postgres_port: 5432
   # the root user
   postgres_user: postgres
-  # append to the global config file.
+  # Append to the varius config files.
   append:
+    # append to gtm.
+    gtm:
+    # append to all proxies.
+    poxy:
+    # append to all datanodes.
+    datanode:
+    # append to all coordinators.
+    coordinators:
 
 security:
   # If exists will load all passwords from secrets.


### PR DESCRIPTION
What:

This bug happens when the configuration for postgres differs from the config for the gtm and proxy. When a value is added to the proxy where the config cannot be read, it crashes the proxy.

Therefore a complete seperation between the configuration for all major parts of the db is best. This PR adds this seperation + a script to initialize the configuration.

See: https://github.com/LamaAni/postgres-xl-helm/issues/18