### PR TITLE
fixes for macos and gke

### DIFF
--- a/experimental/pgbouncer_with_vault/delete.sh
+++ b/experimental/pgbouncer_with_vault/delete.sh
@@ -6,3 +6,4 @@ helm delete vault
 kubectl delete deployment pgbouncer
 kubectl delete service pgbouncer-svc
 kubectl delete pvc data-default-consul-consul-server-0 data-default-consul-consul-server-1 data-default-consul-consul-server-2
+kubectl delete secret pgxl-passwords-collection

--- a/experimental/pgbouncer_with_vault/pgbouncer/pgbouncer-service.yaml
+++ b/experimental/pgbouncer_with_vault/pgbouncer/pgbouncer-service.yaml
@@ -9,4 +9,4 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
-  type: LoadBalancer
+  type: ClusterIP

--- a/experimental/pgbouncer_with_vault/values.yaml
+++ b/experimental/pgbouncer_with_vault/values.yaml
@@ -1,23 +1,17 @@
-# yaml anchor
-small_resource_limit: &small_resource_limit
-  limits:
-    memory: "500Mi"
-    cpu: "250m"
-
 image: sstubbs/pgxl:latest
 
 gtm:
-  resources: *small_resource_limit
+  resources: null
 datanodes:
   count: 1
-  resources: *small_resource_limit
+  resources: null
 coordinators:
   count: 1
-  resources: *small_resource_limit
+  resources: null
 proxies:
   count: 1
   enabled: true
-  resources: *small_resource_limit
+  resources: null
 
 security:
   passwords_secret_name: {{SECRET_NAME}}
@@ -32,11 +26,8 @@ on_load:
   # it right away.
   back_off_limit: 1
   enabled: true
-  resources: *small_resource_limit
+  resources: null
   init:
-    - name: wait_for_connection.sh
-      script: |-
-        sleep 5
     - name: connection_pool_create_base_user.sh
       script: |-
         psql -c "$CONNECTION_POOL_CREATE_BASE_USER"

--- a/experimental/pgbouncer_with_vault/vault/roles/connection-pool-role.sh
+++ b/experimental/pgbouncer_with_vault/vault/roles/connection-pool-role.sh
@@ -15,7 +15,7 @@ CONNECTION_POOL_ROLE_CREATION=(
 
 CONNECTION_POOL_ROLE_CREATION_JSON=$(json_array "${CONNECTION_POOL_ROLE_CREATION[@]}")
 
-kubectl exec -it "${VAULT_NAME}-0" -- vault write database/roles/connection-pool-role \
+kubectl exec "${VAULT_NAME}-0" -- vault write database/roles/connection-pool-role \
   db_name=postgres \
   creation_statements="${CONNECTION_POOL_ROLE_CREATION_JSON}" \
   default_ttl="1h" \


### PR DESCRIPTION
Here are some fixes for pgbouncer_with_vault so it works on gke from kubectl on macos. I've removed the direct resource requests for now so I can see exactly how much resources it uses and set them later.