### PR TITLE
Add support for WAL archive with versions and persistant storage

### DIFF
--- a/examples/deployments/with_archive/README.md
+++ b/examples/deployments/with_archive/README.md
@@ -1,0 +1,9 @@
+# Transient example deployment with WAL archive.
+
+This example creates a transient deployment which will not persist between restarts with additional configuration appended.
+The wal archive will be saved to an empty mount folder, which can be replaced with a pvc.
+
+Alter values as required then sync with helmfile,
+```shell
+helmfile sync
+```

--- a/examples/deployments/with_archive/helmfile.yaml
+++ b/examples/deployments/with_archive/helmfile.yaml
@@ -1,0 +1,15 @@
+# generate a transient postgres-xl db with username and password. This db will
+# NOT be able to withstand restarts.
+releases:
+  - name: tran-with-archive
+    # Use of a specific relaease. 
+    # chart: https://github.com/LamaAni/postgres-xl-helm/archive/0.5.0.tar.gz
+    # Chart in directory
+    chart: ../../../
+    values:
+      - ./values.yaml
+      # can also added inline, example:
+      # - datanodes:
+      #     count: 4  
+      #   coordinators:
+      #     count: 2

--- a/examples/deployments/with_archive/values.yaml
+++ b/examples/deployments/with_archive/values.yaml
@@ -1,0 +1,33 @@
+# used limited resources to allow this
+# deployment to be tested on local systems.
+# Recommended values can be found in README and 
+# in the values file in this chart.
+
+small_resource_limit: &small_resource_limit
+  limits:
+    memory: "500Mi"
+    cpu: "250m"
+
+datanodes:
+  count: 1
+  resources: *small_resource_limit
+coordinators:
+  count: 1
+  resources: *small_resource_limit
+proxies:
+  count: 1
+  resources: *small_resource_limit
+  enabled: true
+
+WAL:
+  archive:
+    enable: true
+    # the version of the archive. Can have multiple versions to allow backup 
+    # and restore from these versions.
+    version: "kka"
+    # use this pvc to allow archiving to be stored over restart.
+    # note that data may be overriden if the db is not up to date.
+    pvc:
+      resources:
+        requests:
+          storage: 1Gi

--- a/examples/deployments/with_archive/values.yaml
+++ b/examples/deployments/with_archive/values.yaml
@@ -27,7 +27,7 @@ WAL:
     version: "kka"
     # use this pvc to allow archiving to be stored over restart.
     # note that data may be overriden if the db is not up to date.
-    pvc:
-      resources:
-        requests:
-          storage: 1Gi
+    # pvc:
+    #   resources:
+    #     requests:
+    #       storage: 1Gi

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,3 @@
 #  NOTICE
 All scripts in this directory will be loaded into the
-`/entry` folder in all executing pods. 
+`/scripts` folder in all executing pods. 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -18,6 +18,8 @@
 : ${LOGGING_ERROR_PREFEX:=":ERROR"}
 : ${LOGGING_WARNING_PREFEX_COLOR:="\e[0;33m"}
 : ${LOGGING_WARNING_PREFEX:=":WARNING"}
+: ${LOGGING_ARCHIVE_PREFEX_COLOR:="\e[0;34m"}
+: ${LOGGING_ARCHIVE_PREFEX:=":INFO"}
 : ${LOGGING_SCRIPT_PREFEX:=":INFO"}
 : ${LOGGING_SCRIPT_PREFEX_COLOR:="\e[0;36m"}
 : ${LOGGING_SCRIPT_TEXT_COLOR:="\e[0;35m"}
@@ -61,6 +63,10 @@ function log:warning() {
 
 function log:script() {
   logging_core_print "SCRIPT" "$@"
+}
+
+function log:archive() {
+  logging_core_print "ARCHIVE" "$@"
 }
 
 function print_bash_error_stack(){

--- a/scripts/wal_archive
+++ b/scripts/wal_archive
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 cur_path="$(dirname ${BASH_SOURCE[0]})"
 source "$cur_path/common.sh"
+source "$cur_path/initialize_env_dependencies"
 
 # loading env.
 SOURCE_WAL_FILE="$1"
@@ -8,14 +9,16 @@ TARGET_WAL_ARCHIVE_NAME="$2"
 
 : ${WAL_ARCHIVE_PATH:="$STORAGE_MOUNT_PATH/wal_archive"}
 
-if [ ! -d "$WAL_ARCHIVE_PATH" ]; then
-  mkdir -p "$WAL_ARCHIVE_PATH"
-  assert $? "Failed to create archive directory" || exit $?
+WAL_ARCHIVE_NODE_PATH="$WAL_ARCHIVE_PATH/$PG_NODE"
 
-  log:archive "Created archive directory @ $WAL_ARCHIVE_PATH"
+if [ ! -d "$WAL_ARCHIVE_NODE_PATH" ]; then
+  mkdir -p "$WAL_ARCHIVE_NODE_PATH"
+  assert $? "Failed to create archive directory @ $WAL_ARCHIVE_NODE_PATH" || exit $?
+
+  log:archive "Created archive directory @ $WAL_ARCHIVE_NODE_PATH"
 fi
 
-archive_to_path="$WAL_ARCHIVE_PATH/$TARGET_WAL_ARCHIVE_NAME"
+archive_to_path="$WAL_ARCHIVE_NODE_PATH/$TARGET_WAL_ARCHIVE_NAME"
 
 # invoke backup logging.
 # TODO: replace with rsync

--- a/scripts/wal_archive
+++ b/scripts/wal_archive
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+cur_path="$(dirname ${BASH_SOURCE[0]})"
+source "$cur_path/common.sh"
+
+# loading env.
+SOURCE_WAL_FILE="$1"
+TARGET_WAL_ARCHIVE_NAME="$2"
+
+: ${WAL_ARCHIVE_PATH:="$STORAGE_MOUNT_PATH/wal_archive"}
+
+if [ ! -d "$WAL_ARCHIVE_PATH" ]; then
+  mkdir -p "$WAL_ARCHIVE_PATH"
+  assert $? "Failed to create archive directory" || exit $?
+
+  log:archive "Created archive directory @ $WAL_ARCHIVE_PATH"
+fi
+
+archive_to_path="$WAL_ARCHIVE_PATH/$TARGET_WAL_ARCHIVE_NAME"
+
+# invoke backup logging.
+# TODO: replace with rsync
+cp -f "$SOURCE_WAL_FILE" "$archive_to_path"
+assert $? "Error while archiving WAL $SOURCE_WAL_FILE -> $archive_to_path"
+log:archive "Archived WAL file $SOURCE_WAL_FILE -> $archive_to_path"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -25,10 +25,15 @@ data:
 {{- if .Values.config.append.proxy }}
 {{ .Values.config.append.proxy | indent 4 }}
 {{- end }}
-
   config_append_datanode: |
     # applies only on startup.
     log_min_messages = {{ lower .Values.config.log_level }}
+{{- if .Values.WAL.archive.enable }}
+    # archive the data
+    archive_mode = on
+    # archive command.
+    archive_command = '/scripts/wal_archive %p %f'
+{{- end }}
 {{- if .Values.config.append.datanode }}
 {{ .Values.config.append.datanode | indent 4 }}
 {{- end }}

--- a/templates/coordinators.yaml
+++ b/templates/coordinators.yaml
@@ -83,17 +83,17 @@ spec:
             name: pg
         command:
           - bash
-          - /entry/coordinator_entrypoint
+          - /scripts/coordinator_entrypoint
         readinessProbe:
           exec:
             command:
-            - /entry/probe_readiness_coordinator
+            - /scripts/probe_readiness_coordinator
           initialDelaySeconds: 5
           periodSeconds: 5
         livenessProbe:
           exec:
             command:
-            - /entry/probe_liveness_postgres
+            - /scripts/probe_liveness_postgres
           initialDelaySeconds: 30
           periodSeconds: 5
         resources:
@@ -117,7 +117,7 @@ spec:
 {{- include "print_password_envs" . | indent 10 }}
         volumeMounts:
           - name: {{$app_name}}-scripts
-            mountPath: /entry
+            mountPath: /scripts
           - name: {{$app_name}}-cfg
             mountPath: /config
           - name: datastore

--- a/templates/datanodes.yaml
+++ b/templates/datanodes.yaml
@@ -49,6 +49,16 @@ spec:
         resources:
 {{ toYaml $config_col.pvc | indent 8 }}
 {{- end }}
+{{- if .Values.WAL.archive.enable }}
+{{- if .Values.WAL.archive.pvc }}
+    - metadata:
+        name: wal-archive
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+{{ toYaml .Values.WAL.archive.pvc | indent 8 }}
+{{- end }}
+{{- end }}
 {{- if $config_col.addVolumeClaims }}
 {{ toYaml $config_col.addVolumeClaims | indent 4 }}
 {{- end }}
@@ -122,6 +132,10 @@ spec:
             mountPath: /config
           - name: datastore
             mountPath: {{ .Values.homedir }}/storage
+{{- if .Values.WAL.archive.enable }}
+          - name: wal-archive
+            mountPath: "{{ .Values.homedir }}/wal_archive"
+{{- end }}
 {{- if $config_col.volumeMounts }}
 {{ toYaml $config_col.volumeMounts | indent 10 }}
 {{- end }}
@@ -135,6 +149,12 @@ spec:
 {{- if $config_col.pvc }}{{- else }}
         - name: datastore
           emptyDir: {}
+{{- end }}
+{{- if .Values.WAL.archive.enable }}
+{{- if $config_col.pvc }}{{- else }}
+        - name: wal-archive
+          emptyDir: {}
+{{- end }}
 {{- end }}
         - name: {{$app_name}}-scripts
           configMap:

--- a/templates/datanodes.yaml
+++ b/templates/datanodes.yaml
@@ -83,17 +83,17 @@ spec:
             name: pg
         command:
           - bash
-          - /entry/data_node_entrypoint
+          - /scripts/data_node_entrypoint
         readinessProbe:
           exec:
             command:
-            - /entry/probe_readiness_datanode
+            - /scripts/probe_readiness_datanode
           initialDelaySeconds: 5
           periodSeconds: 5
         livenessProbe:
           exec:
             command:
-            - /entry/probe_liveness_postgres
+            - /scripts/probe_liveness_postgres
           initialDelaySeconds: 30
           periodSeconds: 5
         resources:
@@ -117,7 +117,7 @@ spec:
 {{- include "print_password_envs" . | indent 10 }}
         volumeMounts:
           - name: {{$app_name}}-scripts
-            mountPath: /entry
+            mountPath: /scripts
           - name: {{$app_name}}-cfg
             mountPath: /config
           - name: datastore

--- a/templates/envs.yaml
+++ b/templates/envs.yaml
@@ -21,6 +21,9 @@ data:
   # the user authentication type 
   AUTH_TYPE: {{ .Values.security.postgres_auth_type }}
 
+  # the wal archive directory. Can be overriden.
+  WAL_ARCHIVE_PATH: "{{ .Values.homedir }}/wal_archive/{{ .Values.WAL.archive.version }}"
+
   # Added envs. These will not affect the db operation.
   {{- if .Values.envs }}
 {{ toYaml .Values.envs | indent 2}}

--- a/templates/gtm.yaml
+++ b/templates/gtm.yaml
@@ -84,7 +84,7 @@ spec:
         image: {{ .Values.image }}
         command:
           - bash
-          - /entry/gtm_entrypoint
+          - /scripts/gtm_entrypoint
         envFrom:
         - configMapRef:
             name: {{$app_name}}-envs
@@ -109,7 +109,7 @@ spec:
 {{- include "print_password_envs" . | indent 10 }}
         volumeMounts:
           - name: {{$app_name}}-scripts
-            mountPath: /entry
+            mountPath: /scripts
           - name: {{$app_name}}-cfg
             mountPath: /config
           - name: datastore

--- a/templates/init.yaml
+++ b/templates/init.yaml
@@ -58,7 +58,7 @@ spec:
         image: "{{ default .Values.image $config_col.image }}"
         command:
           - bash
-          - /entry/job_on_load
+          - /scripts/job_on_load
         envFrom:
         - configMapRef:
             name: {{$app_name}}-envs
@@ -82,7 +82,7 @@ spec:
           - name: {{$app_name}}-load-scripts
             mountPath: /load_scripts
           - name: {{$app_name}}-scripts
-            mountPath: /entry
+            mountPath: /scripts
 {{- if $config_col.volumeMounts }}
 {{ toYaml $config_col.volumeMounts | indent 10 }}
 {{- end }}

--- a/templates/proxies.yaml
+++ b/templates/proxies.yaml
@@ -75,11 +75,11 @@ spec:
             name: gtm
         command:
           - bash
-          - /entry/proxy_entrypoint
+          - /scripts/proxy_entrypoint
         readinessProbe:
           exec:
             command:
-            - /entry/probe_readiness_proxy
+            - /scripts/probe_readiness_proxy
           initialDelaySeconds: 5
           periodSeconds: 5
         resources:
@@ -103,7 +103,7 @@ spec:
 {{- include "print_password_envs" . | indent 10 }}
         volumeMounts:
           - name: {{$app_name}}-scripts
-            mountPath: /entry
+            mountPath: /scripts
           - name: {{$app_name}}-cfg
             mountPath: /config
           - name: datastore

--- a/values.yaml
+++ b/values.yaml
@@ -36,6 +36,22 @@ config:
     # append to all coordinators.
     coordinator:
 
+# applies only to datanodes. Coordinators 
+# are not stored, and are only considered part
+# of the cluster configuration.
+WAL:
+  archive:
+    # enable wal archiving.
+    enable: false
+    # default value for versions.
+    # TODO: add WAL auto versioning on datanode init
+    # will allow restore points.
+    version: "unversioned"
+    # will default to storage.
+    storage_path: /wal_archive
+    # if dose not exist will default to empty folder.
+    pvc:
+
 security:
   # If exists will load all passwords from secrets.
   passwords_secret_name:

--- a/values.yaml
+++ b/values.yaml
@@ -62,6 +62,16 @@ on_load:
   # array of init scripts to be called only when the 
   # the database is first initialized.
   init:
+    # Example sccripts
+    ###
+    # - name: create_database.sh
+    #   script: |-
+    #     psql -c "CREATE DATABASE tester;"
+    #     export PGDATABASE="tester"
+    # - name: create_base_tables.sql
+    #   script: |-
+    #     CREATE SCHEMA test;
+    #     CREATE TABLE test.lama as (SELECT 'the brown rabbit' as col_1);
 
 # the coordinators external service.
 service:


### PR DESCRIPTION
## What:

Add support for WAL archiving of data-nodes.

## Why

To allow datanodes to be stored to remote data, local data, or other storage, an automatic script for storing the WAL was added. Versions are supported to allow data to be versioned. 

Missing: Auto-versioning of data on startup.